### PR TITLE
build: docs: Introduce and document build system for BlocksDS

### DIFF
--- a/Makefile.blocksds
+++ b/Makefile.blocksds
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+BLOCKSDS	?= /opt/blocksds/core
+BLOCKSDSEXT	?= /opt/blocksds/external
+
+# Source code paths
+# -----------------
+
+SOURCEDIRS	:= source
+INCLUDEDIRS	:= include
+GFXDIRS		:=
+BINDIRS		:=
+
+# Defines passed to all files
+# ---------------------------
+
+DEFINES		:= -DBLOCKSDS
+
+# Libraries
+# ---------
+
+LIBDIRS		:= $(BLOCKSDS)/libs/libnds
+
+# Build artifacts
+# ---------------
+
+NAME		:= nflib
+INSTALLNAME	:= nflib
+BUILDDIR	:= build
+ARCHIVE		:= lib/lib$(NAME).a
+
+# Tools
+# -----
+
+PREFIX		:= arm-none-eabi-
+CC		:= $(PREFIX)gcc
+CXX		:= $(PREFIX)g++
+AR		:= ar
+MKDIR		:= mkdir
+RM		:= rm -rf
+CP		:= cp
+INSTALL	:= install
+
+# Verbose flag
+# ------------
+
+ifeq ($(VERBOSE),1)
+V		:=
+else
+V		:= @
+endif
+
+# Source files
+# ------------
+
+ifneq ($(BINDIRS),)
+    SOURCES_BIN	:= $(shell find -L $(BINDIRS) -name "*.bin")
+    INCLUDEDIRS	+= $(addprefix $(BUILDDIR)/,$(BINDIRS))
+endif
+ifneq ($(GFXDIRS),)
+    SOURCES_PNG	:= $(shell find -L $(GFXDIRS) -name "*.png")
+    INCLUDEDIRS	+= $(addprefix $(BUILDDIR)/,$(GFXDIRS))
+endif
+
+SOURCES_S	:= $(shell find -L $(SOURCEDIRS) -name "*.s")
+SOURCES_C	:= $(shell find -L $(SOURCEDIRS) -name "*.c")
+SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
+
+# Compiler and linker flags
+# -------------------------
+
+DEFINES		+= -D__NDS__ -DARM9
+
+ARCH		:= -march=armv5te -mtune=arm946e-s
+
+WARNFLAGS	:= -Wall
+
+INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
+		   $(foreach path,$(LIBDIRS),-I$(path)/include)
+
+ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(ARCH) \
+		   -mthumb -mthumb-interwork $(INCLUDEFLAGS) \
+		   -ffunction-sections -fdata-sections
+
+CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(ARCH) \
+		   -mthumb -mthumb-interwork $(INCLUDEFLAGS) -O2 \
+		   -ffunction-sections -fdata-sections \
+		   -fomit-frame-pointer
+
+CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(ARCH) \
+		   -mthumb -mthumb-interwork $(INCLUDEFLAGS) -O2 \
+		   -ffunction-sections -fdata-sections \
+		   -fno-exceptions -fno-rtti \
+		   -fomit-frame-pointer
+
+# Intermediate build files
+# ------------------------
+
+OBJS_ASSETS	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_PNG)))
+
+HEADERS_ASSETS	:= $(patsubst %.bin,%_bin.h,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN))) \
+		   $(patsubst %.png,%.h,$(addprefix $(BUILDDIR)/,$(SOURCES_PNG)))
+
+OBJS_SOURCES	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_S))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_C))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_CPP)))
+
+OBJS		:= $(OBJS_ASSETS) $(OBJS_SOURCES)
+
+DEPS		:= $(OBJS:.o=.d)
+
+# Targets
+# -------
+
+.PHONY: all clean install
+
+all: $(ARCHIVE)
+
+$(ARCHIVE): $(OBJS)
+	@echo "  AR      $@"
+	@$(MKDIR) -p $(@D)
+	$(V)$(AR) rcs $@ $(OBJS)
+
+clean:
+	@echo "  CLEAN"
+	$(V)$(RM) $(ARCHIVE) $(BUILDDIR)
+
+install: all
+	@echo "  INSTALL $(BLOCKSDSEXT)/$(INSTALLNAME)/"
+	$(V)$(RM) $(BLOCKSDSEXT)/$(INSTALLNAME)/
+	$(V)$(INSTALL) -d $(BLOCKSDSEXT)/$(INSTALLNAME)/
+	$(V)$(CP) -r include lib $(BLOCKSDSEXT)/$(INSTALLNAME)/
+
+# Rules
+# -----
+
+$(BUILDDIR)/%.s.o : %.s
+	@echo "  AS      $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(ASFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.c.o : %.c
+	@echo "  CC      $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.cpp.o : %.cpp
+	@echo "  CXX     $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CXX) $(CXXFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.bin.o $(BUILDDIR)/%_bin.h : %.bin
+	@echo "  BIN2C   $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(BLOCKSDS)/tools/bin2c/bin2c $< $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(BUILDDIR)/$*.bin.o $(BUILDDIR)/$*_bin.c
+
+$(BUILDDIR)/%.png.o $(BUILDDIR)/%.h : %.png %.grit
+	@echo "  GRIT    $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(BLOCKSDS)/tools/grit/grit $< -ftc -W1 -o$(BUILDDIR)/$*
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(BUILDDIR)/$*.png.o $(BUILDDIR)/$*.c
+	$(V)touch $(BUILDDIR)/$*.png.o $(BUILDDIR)/$*.h
+
+# All assets must be built before the source code
+# -----------------------------------------------
+
+$(SOURCES_S) $(SOURCES_C) $(SOURCES_CPP): $(HEADERS_ASSETS)
+
+# Include dependency files if they exist
+# --------------------------------------
+
+-include $(DEPS)

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+build-all/

--- a/examples/3dsprites/Makefile.blocksds
+++ b/examples/3dsprites/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/3dsprites/alpha/Makefile.blocksds
+++ b/examples/3dsprites/alpha/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/3dsprites/alpha/source/main.c
+++ b/examples/3dsprites/alpha/source/main.c
@@ -53,8 +53,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/3dsprites/animation/Makefile.blocksds
+++ b/examples/3dsprites/animation/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/3dsprites/animation/source/main.c
+++ b/examples/3dsprites/animation/source/main.c
@@ -57,8 +57,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/3dsprites/basic/Makefile.blocksds
+++ b/examples/3dsprites/basic/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/3dsprites/basic/source/main.c
+++ b/examples/3dsprites/basic/source/main.c
@@ -55,8 +55,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/3dsprites/rotscale/Makefile.blocksds
+++ b/examples/3dsprites/rotscale/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/3dsprites/rotscale/source/main.c
+++ b/examples/3dsprites/rotscale/source/main.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -224,11 +224,11 @@ int main(int argc, char **argv) {
 
 		// Debug
 		consoleClear();
-		iprintf("A / B - Sprite select %d\n", id);
-		iprintf("Rotate Z (LEFT/RIGHT) %d\n", rz[id]);
-		iprintf("Rotate Y (UP/DOWN) %d\n", ry[id]);
-		iprintf("Rotate X (X/Y) %d\n", rx[id]);
-		iprintf("Scale (R/L) %d\n", scale[id]);
+		printf("A / B - Sprite select %d\n", id);
+		printf("Rotate Z (LEFT/RIGHT) %d\n", rz[id]);
+		printf("Rotate Y (UP/DOWN) %d\n", ry[id]);
+		printf("Rotate X (X/Y) %d\n", rx[id]);
+		printf("Scale (R/L) %d\n", scale[id]);
 
 		// Espera al sincronismo vertical
 		swiWaitForVBlank();

--- a/examples/3dsprites/setlayer/Makefile.blocksds
+++ b/examples/3dsprites/setlayer/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/3dsprites/setlayer/source/main.c
+++ b/examples/3dsprites/setlayer/source/main.c
@@ -57,8 +57,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/3dsprites/setpriority/Makefile.blocksds
+++ b/examples/3dsprites/setpriority/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/3dsprites/setpriority/source/main.c
+++ b/examples/3dsprites/setpriority/source/main.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -175,10 +175,10 @@ int main(int argc, char **argv) {
 		// Debug
 		consoleClear();
 		for (n = 0; n < NF_CREATED_3DSPRITE.total; n ++) {
-			iprintf("Pri:%02d Spr:%02d   Spr:%02d Pri:%02d\n", n, NF_CREATED_3DSPRITE.id[n], n, NF_3DSPRITE[n].prio);
+			printf("Pri:%02d Spr:%02d   Spr:%02d Pri:%02d\n", n, NF_CREATED_3DSPRITE.id[n], n, NF_3DSPRITE[n].prio);
 		}
-		iprintf("\nSprite Id%02d is on %02d priority\n\n", TARGET, NF_3DSPRITE[TARGET].prio);
-		iprintf("A - Near   B - Far");
+		printf("\nSprite Id%02d is on %02d priority\n\n", TARGET, NF_3DSPRITE[TARGET].prio);
+		printf("A - Near   B - Far");
 
 		// Espera al sincronismo vertical
 		swiWaitForVBlank();

--- a/examples/3dsprites/swappriority/Makefile.blocksds
+++ b/examples/3dsprites/swappriority/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/3dsprites/swappriority/source/main.c
+++ b/examples/3dsprites/swappriority/source/main.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -165,9 +165,9 @@ int main(int argc, char **argv) {
 
 		// Debug
 		consoleClear();
-		iprintf("\nSprite Id%02d is on %02d priority\n", 0, NF_3DSPRITE[0].prio);
-		iprintf("Sprite Id%02d is on %02d priority\n\n", (MAXSPRITES - 1), NF_3DSPRITE[(MAXSPRITES - 1)].prio);
-		iprintf("A or B - Swap 0 & %d", (MAXSPRITES - 1));
+		printf("\nSprite Id%02d is on %02d priority\n", 0, NF_3DSPRITE[0].prio);
+		printf("Sprite Id%02d is on %02d priority\n\n", (MAXSPRITES - 1), NF_3DSPRITE[(MAXSPRITES - 1)].prio);
+		printf("A or B - Swap 0 & %d", (MAXSPRITES - 1));
 
 		// Espera al sincronismo vertical
 		swiWaitForVBlank();

--- a/examples/Makefile.blocksds
+++ b/examples/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			$(MAKE) -C $$i -f Makefile.blocksds --no-print-directory || { exit 1;} \
+		fi; \
+	done;
+	@rm -fr build-all
+	@mkdir -p build-all
+	@find . -name "*.nds" -not -path build-all -exec cp -fv {} build-all \;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			$(MAKE) -C $$i -f Makefile.blocksds clean --no-print-directory || { exit 1;} \
+		fi; \
+	done;
+	@rm -fr build-all

--- a/examples/Makefile.example.blocksds
+++ b/examples/Makefile.example.blocksds
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+BLOCKSDS	?= /opt/blocksds/core
+BLOCKSDSEXT	?= /opt/blocksds/external
+
+# User config
+# ===========
+
+NAME		:= $(shell basename $(CURDIR))
+GAME_TITLE	:= $(shell basename $(CURDIR)).nds
+GAME_SUBTITLE	:= NightFox’s lib example
+GAME_AUTHOR	:= github.com/knightfox75/nds_nflib
+GAME_ICON	:= $(BLOCKSDS)/sys/icon.bmp
+
+# Source code paths
+# -----------------
+
+SOURCEDIRS	?= source
+NITROFATDIR	?= nitrofiles
+
+# DLDI and internal SD slot of DSi
+# --------------------------------
+
+# Root folder of the SD image
+SDROOT		:= sdroot
+# Name of the generated image it "DSi-1.sd" for no$gba in DSi mode
+SDIMAGE		:= image.bin
+
+# Libraries
+# ---------
+
+LIBS		+= -lnflib -ldswifi9 -lnds9 -lc
+LIBDIRS		+= $(BLOCKSDSEXT)/nflib \
+		   $(BLOCKSDS)/libs/dswifi \
+		   $(BLOCKSDS)/libs/libnds
+
+# Build artifacts
+# ---------------
+
+BUILDDIR	:= build
+ELF		:= build/$(NAME).elf
+DUMP		:= build/$(NAME).dump
+NITROFAT_IMG	:= build/nitrofat.bin
+MAP		:= build/$(NAME).map
+SOUNDBANKDIR	:= $(BUILDDIR)/maxmod
+ROM		:= $(NAME).nds
+
+# Tools
+# -----
+
+PREFIX		:= arm-none-eabi-
+CC		:= $(PREFIX)gcc
+CXX		:= $(PREFIX)g++
+OBJDUMP		:= $(PREFIX)objdump
+MKDIR		:= mkdir
+RM		:= rm -rf
+
+# Verbose flag
+# ------------
+
+ifeq ($(VERBOSE),1)
+V		:=
+else
+V		:= @
+endif
+
+# Source files
+# ------------
+
+ifneq ($(BINDIRS),)
+    SOURCES_BIN	:= $(shell find -L $(BINDIRS) -name "*.bin")
+    INCLUDEDIRS	+= $(addprefix $(BUILDDIR)/,$(BINDIRS))
+endif
+ifneq ($(GFXDIRS),)
+    SOURCES_PNG	:= $(shell find -L $(GFXDIRS) -name "*.png")
+    INCLUDEDIRS	+= $(addprefix $(BUILDDIR)/,$(GFXDIRS))
+endif
+ifneq ($(AUDIODIRS),)
+    SOURCES_AUDIO	:= $(shell find -L $(AUDIODIRS) -regex '.*\.\(it\|mod\|s3m\|wav\|xm\)')
+    ifneq ($(SOURCES_AUDIO),)
+        INCLUDEDIRS	+= $(SOUNDBANKDIR)
+    endif
+endif
+
+SOURCES_S	:= $(shell find -L $(SOURCEDIRS) -name "*.s")
+SOURCES_C	:= $(shell find -L $(SOURCEDIRS) -name "*.c")
+SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
+
+# Compiler and linker flags
+# -------------------------
+
+DEFINES		+= -D__NDS__ -DARM9
+
+ARCH		:= -march=armv5te -mtune=arm946e-s
+
+WARNFLAGS	:= -Wall
+
+ifeq ($(SOURCES_CPP),)
+    LD	:= $(CC)
+else
+    LD	:= $(CXX)
+endif
+
+INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
+		   $(foreach path,$(LIBDIRS),-I$(path)/include)
+
+LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
+
+ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(ARCH) \
+		   -mthumb -mthumb-interwork $(INCLUDEFLAGS) \
+		   -ffunction-sections -fdata-sections
+
+CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(ARCH) \
+		   -mthumb -mthumb-interwork $(INCLUDEFLAGS) -O2 \
+		   -ffunction-sections -fdata-sections \
+		   -fomit-frame-pointer
+
+CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(ARCH) \
+		   -mthumb -mthumb-interwork $(INCLUDEFLAGS) -O2 \
+		   -ffunction-sections -fdata-sections \
+		   -fno-exceptions -fno-rtti \
+		   -fomit-frame-pointer
+
+LDFLAGS		:= -mthumb -mthumb-interwork $(LIBDIRSFLAGS) \
+		   -Wl,-Map,$(MAP) -Wl,--gc-sections -nostdlib \
+		   -T$(BLOCKSDS)/sys/crts/ds_arm9.mem \
+		   -T$(BLOCKSDS)/sys/crts/ds_arm9.ld \
+		   -Wl,--no-warn-rwx-segments \
+		   -Wl,--start-group $(LIBS) -lgcc -Wl,--end-group
+
+# Intermediate build files
+# ------------------------
+
+OBJS_ASSETS	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_PNG)))
+
+HEADERS_ASSETS	:= $(patsubst %.bin,%_bin.h,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN))) \
+		   $(patsubst %.png,%.h,$(addprefix $(BUILDDIR)/,$(SOURCES_PNG)))
+
+ifneq ($(SOURCES_AUDIO),)
+    OBJS_ASSETS		+= $(SOUNDBANKDIR)/soundbank.c.o
+    HEADERS_ASSETS	+= $(SOUNDBANKDIR)/soundbank.h
+endif
+
+OBJS_SOURCES	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_S))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_C))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_CPP)))
+
+OBJS		:= $(OBJS_ASSETS) $(OBJS_SOURCES)
+
+DEPS		:= $(OBJS:.o=.d)
+
+# Targets
+# -------
+
+.PHONY: all clean dump dldipatch sdimage
+
+all: $(ROM)
+
+ifneq ($(strip $(NITROFATDIR)),)
+# Additional arguments for ndstool
+NDSTOOL_FAT	:= -F $(NITROFAT_IMG)
+
+$(NITROFAT_IMG): $(NITROFATDIR)
+	@echo "  MKFATIMG $@ $(NITROFATDIR)"
+	$(V)$(BLOCKSDS)/tools/mkfatimg/mkfatimg $(NITROFATDIR) $@ 0
+	#$(V)$(BLOCKSDS)/tools/mkfatimg/mkfatimg -t $(NITROFATDIR) $@ 0
+
+# Make the NDS ROM depend on the filesystem image only if it is needed
+$(ROM): $(NITROFAT_IMG)
+endif
+
+# Combine the title strings
+ifeq ($(strip $(GAME_SUBTITLE)),)
+    GAME_FULL_TITLE := $(GAME_TITLE);$(GAME_AUTHOR)
+else
+    GAME_FULL_TITLE := $(GAME_TITLE);$(GAME_SUBTITLE);$(GAME_AUTHOR)
+endif
+
+$(ROM): $(ELF)
+	@echo "  NDSTOOL $@"
+	$(V)$(BLOCKSDS)/tools/ndstool/ndstool -c $@ \
+		-7 $(BLOCKSDS)/sys/default_arm7/arm7.elf -9 $(ELF) \
+		-b $(GAME_ICON) "$(GAME_FULL_TITLE)" \
+		$(NDSTOOL_FAT)
+
+$(ELF): $(OBJS)
+	@echo "  LD      $@"
+	$(V)$(LD) -o $@ $(OBJS) $(BLOCKSDS)/sys/crts/ds_arm9_crt0.o $(LDFLAGS)
+
+$(DUMP): $(ELF)
+	@echo "  OBJDUMP   $@"
+	$(V)$(OBJDUMP) -h -C -S $< > $@
+
+dump: $(DUMP)
+
+clean:
+	@echo "  CLEAN"
+	$(V)$(RM) $(ROM) $(DUMP) $(BUILDDIR) $(SDIMAGE)
+
+sdimage:
+	@echo "  MKFATIMG $(SDIMAGE) $(SDROOT)"
+	$(V)$(BLOCKSDS)/tools/mkfatimg/mkfatimg -t $(SDROOT) $(SDIMAGE) 0
+
+dldipatch: $(ROM)
+	@echo "  DLDITOOL $(ROM)"
+	$(V)$(BLOCKSDS)/tools/dlditool/dlditool \
+		$(BLOCKSDS)/tools/dldi/r4tfv2.dldi $(ROM)
+
+# Rules
+# -----
+
+$(BUILDDIR)/%.s.o : %.s
+	@echo "  AS      $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(ASFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.c.o : %.c
+	@echo "  CC      $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.cpp.o : %.cpp
+	@echo "  CXX     $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CXX) $(CXXFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.bin.o $(BUILDDIR)/%_bin.h : %.bin
+	@echo "  BIN2C   $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(BLOCKSDS)/tools/bin2c/bin2c $< $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(BUILDDIR)/$*.bin.o $(BUILDDIR)/$*_bin.c
+
+$(BUILDDIR)/%.png.o $(BUILDDIR)/%.h : %.png %.grit
+	@echo "  GRIT    $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(BLOCKSDS)/tools/grit/grit $< -ftc -W1 -o$(BUILDDIR)/$*
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(BUILDDIR)/$*.png.o $(BUILDDIR)/$*.c
+
+$(SOUNDBANKDIR)/soundbank.h: $(SOURCES_AUDIO)
+	@echo "  MMUTIL  $^"
+	@$(MKDIR) -p $(@D)
+	@$(BLOCKSDS)/tools/mmutil/mmutil $^ -d \
+		-o$(SOUNDBANKDIR)/soundbank.bin -h$(SOUNDBANKDIR)/soundbank.h
+
+$(SOUNDBANKDIR)/soundbank.c.o: $(SOUNDBANKDIR)/soundbank.h
+	@echo "  BIN2C   soundbank.bin"
+	$(V)$(BLOCKSDS)/tools/bin2c/bin2c $(SOUNDBANKDIR)/soundbank.bin \
+		$(SOUNDBANKDIR)
+	@echo "  CC.9    soundbank_bin.c"
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(SOUNDBANKDIR)/soundbank.c.o \
+		$(SOUNDBANKDIR)/soundbank_bin.c
+
+# All assets must be built before the source code
+# -----------------------------------------------
+
+$(SOURCES_S) $(SOURCES_C) $(SOURCES_CPP): $(HEADERS_ASSETS)
+
+# Include dependency files if they exist
+# --------------------------------------
+
+-include $(DEPS)
+

--- a/examples/colisions/Makefile.blocksds
+++ b/examples/colisions/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/colisions/barrels/Makefile.blocksds
+++ b/examples/colisions/barrels/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/colisions/barrels/source/main.c
+++ b/examples/colisions/barrels/source/main.c
@@ -52,8 +52,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
 			NF_MoveSprite(0, b, x[b], y[b]);
 
 			// Imprime la posicion de la pelota
-			iprintf("x:%03d  y:%03d\n", x[b], y[b]);
+			printf("x:%03d  y:%03d\n", x[b], y[b]);
 
 		}
 

--- a/examples/colisions/pixels/Makefile.blocksds
+++ b/examples/colisions/pixels/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/colisions/pixels/source/main.c
+++ b/examples/colisions/pixels/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -137,25 +137,25 @@ int main(int argc, char **argv) {
 
 		// Imprime la posicion del cursor
 		consoleClear();
-		iprintf("x:%03d  y:%03d \n\n", x, y);
+		printf("x:%03d  y:%03d \n\n", x, y);
 
 		// Imprime el color del pixel
 		pixel = NF_GetPoint(0, x, y);
 		switch (pixel) {
 			case 1:
-				iprintf("Tile: Negro / Black");
+				printf("Tile: Negro / Black");
 				break;
 			case 2:
-				iprintf("Tile: Rojo / Red");
+				printf("Tile: Rojo / Red");
 				break;
 			case 3:
-				iprintf("Tile: Verde / Green");
+				printf("Tile: Verde / Green");
 				break;
 			case 4:
-				iprintf("Tile: Azul / Blue");
+				printf("Tile: Azul / Blue");
 				break;
 			default:
-				iprintf("Value: %03d", pixel); 
+				printf("Value: %03d", pixel); 
 				break;
 		}
 

--- a/examples/colisions/tiles/Makefile.blocksds
+++ b/examples/colisions/tiles/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/colisions/tiles/source/main.c
+++ b/examples/colisions/tiles/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/demo/Makefile.blocksds
+++ b/examples/demo/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/demo/reveal/Makefile.blocksds
+++ b/examples/demo/reveal/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/demo/reveal/source/main.c
+++ b/examples/demo/reveal/source/main.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/demo/water/Makefile.blocksds
+++ b/examples/demo/water/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/demo/water/source/main.c
+++ b/examples/demo/water/source/main.c
@@ -68,8 +68,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/demo/wave/Makefile.blocksds
+++ b/examples/demo/wave/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/demo/wave/source/main.c
+++ b/examples/demo/wave/source/main.c
@@ -67,8 +67,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/demo/zoomx2/Makefile.blocksds
+++ b/examples/demo/zoomx2/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/demo/zoomx2/source/main.c
+++ b/examples/demo/zoomx2/source/main.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/demo/zoomx3/Makefile.blocksds
+++ b/examples/demo/zoomx3/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/demo/zoomx3/source/main.c
+++ b/examples/demo/zoomx3/source/main.c
@@ -55,8 +55,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/Makefile.blocksds
+++ b/examples/graphics/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/graphics/affine/Makefile.blocksds
+++ b/examples/graphics/affine/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/affine/source/main.c
+++ b/examples/graphics/affine/source/main.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/alpha/Makefile.blocksds
+++ b/examples/graphics/alpha/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/alpha/source/main.c
+++ b/examples/graphics/alpha/source/main.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/animatedbg/Makefile.blocksds
+++ b/examples/graphics/animatedbg/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/animatedbg/source/main.c
+++ b/examples/graphics/animatedbg/source/main.c
@@ -71,8 +71,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/backbuffer/Makefile.blocksds
+++ b/examples/graphics/backbuffer/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/backbuffer2/Makefile.blocksds
+++ b/examples/graphics/backbuffer2/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/backbuffer2/source/main.c
+++ b/examples/graphics/backbuffer2/source/main.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/backbuffer3/Makefile.blocksds
+++ b/examples/graphics/backbuffer3/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/backbuffer3/source/main.c
+++ b/examples/graphics/backbuffer3/source/main.c
@@ -55,8 +55,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/backbuffer4/Makefile.blocksds
+++ b/examples/graphics/backbuffer4/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/backbuffer4/source/main.c
+++ b/examples/graphics/backbuffer4/source/main.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/bg/Makefile.blocksds
+++ b/examples/graphics/bg/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/bg/source/main.c
+++ b/examples/graphics/bg/source/main.c
@@ -55,8 +55,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/bg16bits/Makefile.blocksds
+++ b/examples/graphics/bg16bits/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/bg16bitsload/Makefile.blocksds
+++ b/examples/graphics/bg16bitsload/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/bg16bitsload/source/main.c
+++ b/examples/graphics/bg16bitsload/source/main.c
@@ -53,8 +53,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/bg8bits/Makefile.blocksds
+++ b/examples/graphics/bg8bits/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/bg8bits/source/main.c
+++ b/examples/graphics/bg8bits/source/main.c
@@ -53,8 +53,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/bgextpalette/Makefile.blocksds
+++ b/examples/graphics/bgextpalette/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/bgextpalette/source/main.c
+++ b/examples/graphics/bgextpalette/source/main.c
@@ -59,8 +59,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/bgmixed/Makefile.blocksds
+++ b/examples/graphics/bgmixed/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/bgmixed/source/main.c
+++ b/examples/graphics/bgmixed/source/main.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/bgpalette/Makefile.blocksds
+++ b/examples/graphics/bgpalette/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/bgpalette/source/main.c
+++ b/examples/graphics/bgpalette/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
 	while(1) {
 
 		myvar ++;
-		sprintf(mytext,"Contador: %d", myvar);
+		snprintf(mytext, sizeof(mytext), "Contador: %lu", myvar);
 		NF_WriteText(0, 0, 1, 5, mytext);
 		NF_WriteText(0, 1, 1, 5, mytext);
 		NF_WriteText(0, 2, 1, 5, mytext);

--- a/examples/graphics/imgdraw/Makefile.blocksds
+++ b/examples/graphics/imgdraw/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/imgdraw/source/main.c
+++ b/examples/graphics/imgdraw/source/main.c
@@ -53,8 +53,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/sprite/Makefile.blocksds
+++ b/examples/graphics/sprite/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/sprite/source/main.c
+++ b/examples/graphics/sprite/source/main.c
@@ -52,8 +52,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/spritepal/Makefile.blocksds
+++ b/examples/graphics/spritepal/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/spritepal/source/main.c
+++ b/examples/graphics/spritepal/source/main.c
@@ -52,8 +52,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/tilechange/Makefile.blocksds
+++ b/examples/graphics/tilechange/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/tilechange/source/main.c
+++ b/examples/graphics/tilechange/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/graphics/tileflip/Makefile.blocksds
+++ b/examples/graphics/tileflip/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/graphics/tileflip/source/main.c
+++ b/examples/graphics/tileflip/source/main.c
@@ -55,8 +55,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/media/Makefile.blocksds
+++ b/examples/media/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Zlib
+#
+# Copyright (c) 2023 Antonio Niño Díaz
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/media/bmpload/Makefile.blocksds
+++ b/examples/media/bmpload/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/media/bmpload/source/main.c
+++ b/examples/media/bmpload/source/main.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/media/bmpscroll/Makefile.blocksds
+++ b/examples/media/bmpscroll/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/media/bmpscroll/source/main.c
+++ b/examples/media/bmpscroll/source/main.c
@@ -53,8 +53,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/misc/Makefile.blocksds
+++ b/examples/misc/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/misc/language/Makefile.blocksds
+++ b/examples/misc/language/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/misc/language/source/main.c
+++ b/examples/misc/language/source/main.c
@@ -56,28 +56,28 @@ int main(int argc, char **argv) {
 	// Imprime en pantalla el idioma del usuario
 	switch (NF_GetLanguage()) {
 		case 0 : // Japanese
-			iprintf("Japanese");
+			printf("Japanese");
 			break;
 		case 1 : // English
-			iprintf("English");
+			printf("English");
 			break;
 		case 2 : // French
-			iprintf("French");
+			printf("French");
 			break;
 		case 3 : // German
-			iprintf("German");
+			printf("German");
 			break;
 		case 4 : // Italian
-			iprintf("Italian");
+			printf("Italian");
 			break;
 		case 5 : // Spanish
-			iprintf("Spanish");
+			printf("Spanish");
 			break;
 		case 6 : // Chinese
-			iprintf("Chinese");
+			printf("Chinese");
 			break;
 		default:
-			iprintf("Error");
+			printf("Error");
 			break;
 	}
 

--- a/examples/sound/Makefile.blocksds
+++ b/examples/sound/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/sound/rawsfx/Makefile.blocksds
+++ b/examples/sound/rawsfx/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/sound/rawsfx/source/main.c
+++ b/examples/sound/rawsfx/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/text/Makefile.blocksds
+++ b/examples/text/Makefile.blocksds
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile.blocksds ; then \
+			cd $$i; \
+			$(MAKE) -f Makefile.blocksds clean --no-print-directory || { exit 1;}; \
+			cd ..; \
+		fi; \
+	done;

--- a/examples/text/text16/Makefile.blocksds
+++ b/examples/text/text16/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/text/text16/source/main.c
+++ b/examples/text/text16/source/main.c
@@ -59,8 +59,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/text/textcolor/Makefile.blocksds
+++ b/examples/text/textcolor/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/text/textcolor/source/main.c
+++ b/examples/text/textcolor/source/main.c
@@ -59,8 +59,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/examples/text/textdemo/Makefile.blocksds
+++ b/examples/text/textdemo/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/text/textdemo/source/main.c
+++ b/examples/text/textdemo/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
 	while(1) {
 
 		myvar ++;
-		sprintf(mytext,"Contador: %d", myvar);
+		snprintf(mytext, sizeof(mytext), "Contador: %lu", myvar);
 		NF_WriteText(0, 0, 1, 5, mytext);
 		NF_WriteText(0, 1, 1, 5, mytext);
 		NF_WriteText(0, 2, 1, 5, mytext);

--- a/examples/text/textdemo16/Makefile.blocksds
+++ b/examples/text/textdemo16/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/text/textdemo16/source/main.c
+++ b/examples/text/textdemo16/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
 	while(1) {
 
 		myvar ++;
-		sprintf(mytext,"Contador: %d", myvar);
+		snprintf(mytext, sizeof(mytext), "Contador: %lu", myvar);
 		NF_WriteText16(0, 0, 1, 4, mytext);
 		NF_WriteText16(1, 1, 1, 4, mytext);
 		NF_WriteText16(1, 2, 1, 4, mytext);

--- a/examples/text/textscroll/Makefile.blocksds
+++ b/examples/text/textscroll/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../Makefile.example.blocksds

--- a/examples/text/textscroll/source/main.c
+++ b/examples/text/textscroll/source/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv) {
 	NF_Set2D(0, 0);
 	NF_Set2D(1, 0);	
 	consoleDemoInit();
-	iprintf("\n NitroFS init. Please wait.\n\n");
-	iprintf(" Iniciando NitroFS,\n por favor, espere.\n\n");
+	printf("\n NitroFS init. Please wait.\n\n");
+	printf(" Iniciando NitroFS,\n por favor, espere.\n\n");
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos

--- a/extras/wifi/examples/udptalk/Makefile.blocksds
+++ b/extras/wifi/examples/udptalk/Makefile.blocksds
@@ -1,0 +1,1 @@
+include ../../../../examples/Makefile.example.blocksds

--- a/extras/wifi/examples/udptalk/source/main.c
+++ b/extras/wifi/examples/udptalk/source/main.c
@@ -136,15 +136,15 @@ int main(int argc, char **argv) {
 					}
 
 					// Envia y verifica si se han recibido
-					iprintf("Envio: %s\n", temp);
+					printf("Envio: %s\n", temp);
 					if (_SendData(temp) > 0) {
 						// Imprime los datos recibidos
-						iprintf("Verificado: %s\n\n", NF_RECV_BUFFER);
+						printf("Verificado: %s\n\n", NF_RECV_BUFFER);
 						// Incrementa el valor
 						contador ++;
 						if (contador > 9999) contador = 0;
 					} else {
-						iprintf("Error de envio.\n");
+						printf("Error de envio.\n");
 					}
 
 				}
@@ -158,12 +158,12 @@ int main(int argc, char **argv) {
 				// Recibe los datos
 				if (_GetData() > 0) {
 					// Imprime los datos recibidos
-					iprintf("Recivido: %s\n", NF_RECV_BUFFER);
+					printf("Recivido: %s\n", NF_RECV_BUFFER);
 					// Si has recibido la señal de salida...
 					if (strcmp(NF_RECV_BUFFER, "Exit") == 0) loop = false;
 				} else {
 					// Si no hay datos, esperalos
-					iprintf("Esperando datos...\n");
+					printf("Esperando datos...\n");
 				}
 
 			}
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
 	NF_WiFiDisconnectAp();
 
 	// Informa
-	iprintf("\nSesion finalizada\n");
+	printf("\nSesion finalizada\n");
 
 	while (1) {
 		swiWaitForVBlank();
@@ -209,18 +209,18 @@ bool _ConnectWIFI(void) {
 	bool status = false;
 
 	// Intenta conectarte al AP...
-	iprintf("Conectando via WFC...\n\n");
+	printf("Conectando via WFC...\n\n");
 	swiWaitForVBlank();
 
 	if (NF_WiFiConnectDefaultAp()) {
 
 		// Devuelve los parametros de la conexion TCP/IP con el AP
-		iprintf("Conexion realizada.\n\n");
-		iprintf("Ip     : %s\n", inet_ntoa(NF_IP));
-		iprintf("Gateway: %s\n", inet_ntoa(NF_GATEWAY));
-		iprintf("Mask   : %s\n", inet_ntoa(NF_MASK));
-		iprintf("Dns1   : %s\n", inet_ntoa(NF_DNS1));
-		iprintf("Dns2   : %s\n\n", inet_ntoa(NF_DNS2));
+		printf("Conexion realizada.\n\n");
+		printf("Ip     : %s\n", inet_ntoa(NF_IP));
+		printf("Gateway: %s\n", inet_ntoa(NF_GATEWAY));
+		printf("Mask   : %s\n", inet_ntoa(NF_MASK));
+		printf("Dns1   : %s\n", inet_ntoa(NF_DNS1));
+		printf("Dns2   : %s\n\n", inet_ntoa(NF_DNS2));
 		
 		// Marca como conectado
 		status = true;
@@ -228,7 +228,7 @@ bool _ConnectWIFI(void) {
 	} else {
 
 		// No se ha podido conectar
-		iprintf("Conexion no establecida\n");
+		printf("Conexion no establecida\n");
 
 	}
 
@@ -245,7 +245,7 @@ u8 _SelectMode(void) {
 	u8 modo = 0;
 	u16 keys = 0;
 
-	iprintf("A - Cliente\nB - Servidor\n");
+	printf("A - Cliente\nB - Servidor\n");
 	swiWaitForVBlank();
 
 	while (modo == 0) {
@@ -365,7 +365,7 @@ s16 _LookForServer(void) {
 
 		// Calcula la IP
 		sprintf(temp, "%s%d", myip, n);
-		iprintf("%s   ", temp);
+		printf("%s   ", temp);
 		swiWaitForVBlank();
 
 		// Crea el socket de envio
@@ -377,14 +377,14 @@ s16 _LookForServer(void) {
 			status = _SendData("HANDSHAKE");
 			if (status > 0) {
 				// Imprime los datos recibidos
-				iprintf("Encontrado.\n");
+				printf("Encontrado.\n");
 				// Guarda el valor
 				sprintf(server_ip, temp);
 				p = n;
 				n = 255;
 				loop = false;
 			} else {
-				iprintf("Time Out.\n");
+				printf("Time Out.\n");
 				if (status == -2) loop = false;
 			}
 		}

--- a/readme.rst
+++ b/readme.rst
@@ -1,12 +1,13 @@
+##############
 NightFox’s Lib
-==============
+##############
 
 Introduction
-------------
+============
 
 NightFox’s Lib is a library written in C to make it easier to develop for the
-NDS. It depends on libnds by devkitPro, but it makes it much easier to use
-backgrounds, sprites, collision maps, etc.
+NDS. It depends on libnds, but it is much easier than libnds if the user wants
+to use backgrounds, sprites, collision maps, etc.
 
 Features:
 
@@ -86,8 +87,8 @@ Features:
 
   - Available in PDF format in English and Spanish.
 
-Setup
------
+Setup instructions for devkitPro
+================================
 
 1. Clone this repository. Create a symbolic link to it inside the devkitPro
    folder in your system. For example, in Linux, create a symlink so that
@@ -106,4 +107,25 @@ Setup
 
        make
 
-3. That's it! Go to any of the examples and try to build it with ``make``.
+3. That's it! Go to the folder of any of the examples and try to build it with:
+
+   .. code:: bash
+
+       make
+
+Setup instructions for BlocksDS
+===============================
+
+1. Clone this repository. If you have followed the tutorial of `BlocksDS
+   <https://github.com/blocksds/sdk>`_, you should have the compiler in your
+   ``PATH``. All you have to do is go to the folder of the repository and run:
+
+   .. code:: bash
+
+       make -f Makefile.blocksds install
+
+2. That's it! Go to the folder of any of the examples and try to build it with:
+
+   .. code:: bash
+
+       make -f Makefile.blocksds

--- a/source/nf_basic.c
+++ b/source/nf_basic.c
@@ -7,6 +7,9 @@
 // Version 
 
 
+#ifdef BLOCKSDS
+#define iprintf printf
+#endif
 
 // Includes devKitPro
 #include <nds.h>


### PR DESCRIPTION
Also, some minor fixes to the examples so that they can build.

All ``iprintf()`` calls in the examples have been replaced by
``printf()``. In devkitPro, this increases the size of the binary
(because ``printf()`` and ``iprintf()`` are two different functions).
However, in an example this isn't a big problem.

In BlocksDS, which uses ``picolibc`` instead of ``newlib``, the
non-standard ``iprintf()`` doesn't exist.

Also, add makefiles to build all examples in one command.