### PR TITLE
license: Change to CC BY 4.0

### DIFF
--- a/include/nf_2d.h
+++ b/include/nf_2d.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_3d.h
+++ b/include/nf_3d.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_affinebg.h
+++ b/include/nf_affinebg.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_basic.h
+++ b/include/nf_basic.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_bitmapbg.h
+++ b/include/nf_bitmapbg.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_colision.h
+++ b/include/nf_colision.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_defines.h
+++ b/include/nf_defines.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_lib.h
+++ b/include/nf_lib.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_media.h
+++ b/include/nf_media.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_mixedbg.h
+++ b/include/nf_mixedbg.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_sound.h
+++ b/include/nf_sound.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_sprite256.h
+++ b/include/nf_sprite256.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_sprite3d.h
+++ b/include/nf_sprite3d.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_text.h
+++ b/include/nf_text.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_text16.h
+++ b/include/nf_text16.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/include/nf_tiledbg.h
+++ b/include/nf_tiledbg.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/license.txt
+++ b/license.txt
@@ -1,15 +1,16 @@
 NFLib is distributed under CREATIVE COMMONS licence:
 
-https://creativecommons.org/licenses/by-nc/4.0/
+https://creativecommons.org/licenses/by/4.0/
 
-Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
-==========================================================
+Attribution 4.0 International (CC BY 4.0)
+=========================================
 
 You are free to:
 ----------------
 
 - Share: copy and redistribute the material in any medium or format.
-- Adapt: remix, transform, and build upon the material.
+- Adapt: remix, transform, and build upon the material for any purpose, even
+  commercially.
 
 The licensor cannot revoke these freedoms as long as you follow the license
 terms.
@@ -20,8 +21,6 @@ Under the following terms:
 - Attribution: You must give appropriate credit, provide a link to the license,
   and indicate if changes were made. You may do so in any reasonable manner, but
   not in any way that suggests the licensor endorses you or your use.
-
-- NonCommercial: You may not use the material for commercial purposes.
 
 No additional restrictions: You may not apply legal terms or technological
 measures that legally restrict others from doing anything the license permits.

--- a/source/nf_2d.c
+++ b/source/nf_2d.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_3d.c
+++ b/source/nf_3d.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_affinebg.c
+++ b/source/nf_affinebg.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_basic.c
+++ b/source/nf_basic.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_bitmapbg.c
+++ b/source/nf_bitmapbg.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_colision.c
+++ b/source/nf_colision.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_media.c
+++ b/source/nf_media.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_mixedbg.c
+++ b/source/nf_mixedbg.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_sound.c
+++ b/source/nf_sound.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_sprite256.c
+++ b/source/nf_sprite256.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_sprite3d.c
+++ b/source/nf_sprite3d.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_text.c
+++ b/source/nf_text.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_text16.c
+++ b/source/nf_text16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //

--- a/source/nf_tiledbg.c
+++ b/source/nf_tiledbg.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: CC-BY-4.0
 //
 // Copyright (c) 2011-2014 Cesar Rincon "NightFox"
 //


### PR DESCRIPTION
The previous license was CC BY-NC 4.0, which doesn't allow commercial use of the library. Nowadays this exception isn't really helpful, and it may discourage people that are thinking about using the library (and may be thinking about maybe selling the ROM in websites like itch.io).