### PR TITLE
license: Fix licenses

### DIFF
--- a/examples/3dsprites/alpha/source/main.c
+++ b/examples/3dsprites/alpha/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/3dsprites/animation/source/main.c
+++ b/examples/3dsprites/animation/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/3dsprites/basic/source/main.c
+++ b/examples/3dsprites/basic/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/3dsprites/rotscale/source/main.c
+++ b/examples/3dsprites/rotscale/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/3dsprites/setlayer/source/main.c
+++ b/examples/3dsprites/setlayer/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/3dsprites/setpriority/source/main.c
+++ b/examples/3dsprites/setpriority/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/3dsprites/swappriority/source/main.c
+++ b/examples/3dsprites/swappriority/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/colisions/barrels/source/main.c
+++ b/examples/colisions/barrels/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/colisions/pixels/source/main.c
+++ b/examples/colisions/pixels/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/colisions/tiles/source/main.c
+++ b/examples/colisions/tiles/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/demo/reveal/source/main.c
+++ b/examples/demo/reveal/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/demo/water/source/main.c
+++ b/examples/demo/water/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/demo/wave/source/main.c
+++ b/examples/demo/wave/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/demo/zoomx2/source/main.c
+++ b/examples/demo/zoomx2/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/demo/zoomx3/source/main.c
+++ b/examples/demo/zoomx3/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/affine/source/main.c
+++ b/examples/graphics/affine/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com/
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/alpha/source/main.c
+++ b/examples/graphics/alpha/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -12,8 +16,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/animatedbg/source/main.c
+++ b/examples/graphics/animatedbg/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/backbuffer/source/main.c
+++ b/examples/graphics/backbuffer/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/backbuffer2/source/main.c
+++ b/examples/graphics/backbuffer2/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/backbuffer3/source/main.c
+++ b/examples/graphics/backbuffer3/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -12,8 +16,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/backbuffer4/source/main.c
+++ b/examples/graphics/backbuffer4/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -11,8 +15,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/bg/source/main.c
+++ b/examples/graphics/bg/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/bg16bits/source/main.c
+++ b/examples/graphics/bg16bits/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/bg16bitsload/source/main.c
+++ b/examples/graphics/bg16bitsload/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/bg8bits/source/main.c
+++ b/examples/graphics/bg8bits/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/bgextpalette/source/main.c
+++ b/examples/graphics/bgextpalette/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/bgmixed/source/main.c
+++ b/examples/graphics/bgmixed/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/bgpalette/source/main.c
+++ b/examples/graphics/bgpalette/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/imgdraw/source/main.c
+++ b/examples/graphics/imgdraw/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/sprite/source/main.c
+++ b/examples/graphics/sprite/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c) 2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/spritepal/source/main.c
+++ b/examples/graphics/spritepal/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/tilechange/source/main.c
+++ b/examples/graphics/tilechange/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/graphics/tileflip/source/main.c
+++ b/examples/graphics/tileflip/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/media/bmpload/source/main.c
+++ b/examples/media/bmpload/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c) 2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/media/bmpscroll/source/main.c
+++ b/examples/media/bmpscroll/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c) 2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/misc/language/source/main.c
+++ b/examples/misc/language/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/sound/rawsfx/source/main.c
+++ b/examples/sound/rawsfx/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/text/text16/source/main.c
+++ b/examples/text/text16/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2010
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2010 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/text/textcolor/source/main.c
+++ b/examples/text/textcolor/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/text/textdemo/source/main.c
+++ b/examples/text/textdemo/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/text/textdemo16/source/main.c
+++ b/examples/text/textdemo16/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/examples/text/textscroll/source/main.c
+++ b/examples/text/textscroll/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/extras/wifi/examples/udptalk/source/main.c
+++ b/extras/wifi/examples/udptalk/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2010
+
 /*
 -------------------------------------------------
 
@@ -10,8 +14,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 NightFox & Co.
 
 -------------------------------------------------
 */

--- a/extras/wifi/examples/udptalk/source/nf_wifi.c
+++ b/extras/wifi/examples/udptalk/source/nf_wifi.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de WI-FI
 // http://www.nightfoxandco.com/

--- a/extras/wifi/examples/udptalk/source/nf_wifi.h
+++ b/extras/wifi/examples/udptalk/source/nf_wifi.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones de WI-FI
 // http://www.nightfoxandco.com/

--- a/extras/wifi/lib/nf_wifi.c
+++ b/extras/wifi/lib/nf_wifi.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de WI-FI
 // http://www.nightfoxandco.com/

--- a/extras/wifi/lib/nf_wifi.h
+++ b/extras/wifi/lib/nf_wifi.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-NC-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones de WI-FI
 // http://www.nightfoxandco.com/

--- a/include/nf_2d.h
+++ b/include/nf_2d.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones 2D comunes
 // http://www.nightfoxandco.com/

--- a/include/nf_3d.h
+++ b/include/nf_3d.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones 3D
 // http://www.nightfoxandco.com/

--- a/include/nf_affinebg.h
+++ b/include/nf_affinebg.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Includes de Fondos Affine
 // http://www.nightfoxandco.com/

--- a/include/nf_basic.h
+++ b/include/nf_basic.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones basicas
 // http://www.nightfoxandco.com/

--- a/include/nf_bitmapbg.h
+++ b/include/nf_bitmapbg.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones de fondos en modo Bitmap
 // http://www.nightfoxandco.com/

--- a/include/nf_colision.h
+++ b/include/nf_colision.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de Colisiones
 // http://www.nightfoxandco.com/

--- a/include/nf_defines.h
+++ b/include/nf_defines.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Definiciones General
 // http://www.nightfoxandco.com/

--- a/include/nf_lib.h
+++ b/include/nf_lib.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include General
 // http://www.nightfoxandco.com/

--- a/include/nf_media.h
+++ b/include/nf_media.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones de carga de archivos multimedia
 // http://www.nightfoxandco.com/

--- a/include/nf_mixedbg.h
+++ b/include/nf_mixedbg.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de Fondos mixtos (Tiled / Bitmap 8 bits)
 // http://www.nightfoxandco.com/

--- a/include/nf_sound.h
+++ b/include/nf_sound.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones de sonido
 // http://www.nightfoxandco.com/

--- a/include/nf_sprite256.h
+++ b/include/nf_sprite256.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de Sprites a 256 colores
 // http://www.nightfoxandco.com/

--- a/include/nf_sprite3d.h
+++ b/include/nf_sprite3d.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones 3D
 // http://www.nightfoxandco.com/

--- a/include/nf_text.h
+++ b/include/nf_text.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de Textos
 // http://www.nightfoxandco.com/

--- a/include/nf_text16.h
+++ b/include/nf_text16.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de Textos de 16 pixels
 // http://www.nightfoxandco.com/

--- a/include/nf_tiledbg.h
+++ b/include/nf_tiledbg.h
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de Fondos con tiles
 // http://www.nightfoxandco.com/

--- a/licenses/cc-by-4.0.txt
+++ b/licenses/cc-by-4.0.txt
@@ -1,4 +1,4 @@
-NFLib is distributed under CREATIVE COMMONS licence:
+The assets of NFLib are distributed under CREATIVE COMMONS licence:
 
 https://creativecommons.org/licenses/by/4.0/
 

--- a/licenses/cc0-1.0.txt
+++ b/licenses/cc0-1.0.txt
@@ -1,0 +1,125 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL
+SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT
+RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS.
+CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE
+INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES
+RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of authorship
+and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific works
+("Commons") that the public can reliably and without fear of later claims of
+infringement build upon, modify, incorporate in other works, reuse and
+redistribute as freely as possible in any form whatsoever and for any purposes,
+including without limitation commercial purposes. These owners may contribute to
+the Commons to promote the ideal of a free culture and the further production of
+creative, cultural and scientific works, or to gain reputation or greater
+distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of
+additional consideration or compensation, the person associating CC0 with a Work
+(the "Affirmer"), to the extent that he or she is an owner of Copyright and
+Related Rights in the Work, voluntarily elects to apply CC0 to the Work and
+publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+    1. Copyright and Related Rights. A Work made available under CC0 may be
+    protected by copyright and related or neighboring rights ("Copyright and
+    Related Rights"). Copyright and Related Rights include, but are not limited
+    to, the following:
+
+        i. the right to reproduce, adapt, distribute, perform, display,
+        communicate, and translate a Work;
+
+        ii. moral rights retained by the original author(s) and/or performer(s);
+
+        iii. publicity and privacy rights pertaining to a person's image or
+        likeness depicted in a Work;
+
+        iv. rights protecting against unfair competition in regards to a Work,
+        subject to the limitations in paragraph 4(a), below;
+
+        v. rights protecting the extraction, dissemination, use and reuse of
+        data in a Work;
+
+        vi. database rights (such as those arising under Directive 96/9/EC of
+        the European Parliament and of the Council of 11 March 1996 on the legal
+        protection of databases, and under any national implementation thereof,
+        including any amended or successor version of such directive); and
+
+        vii. other similar, equivalent or corresponding rights throughout the
+        world based on applicable law or treaty, and any national
+        implementations thereof.
+
+    2. Waiver. To the greatest extent permitted by, but not in contravention of,
+    applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+    unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+    and Related Rights and associated claims and causes of action, whether now
+    known or unknown (including existing as well as future claims and causes of
+    action), in the Work (i) in all territories worldwide, (ii) for the maximum
+    duration provided by applicable law or treaty (including future time
+    extensions), (iii) in any current or future medium and for any number of
+    copies, and (iv) for any purpose whatsoever, including without limitation
+    commercial, advertising or promotional purposes (the "Waiver"). Affirmer
+    makes the Waiver for the benefit of each member of the public at large and
+    to the detriment of Affirmer's heirs and successors, fully intending that
+    such Waiver shall not be subject to revocation, rescission, cancellation,
+    termination, or any other legal or equitable action to disrupt the quiet
+    enjoyment of the Work by the public as contemplated by Affirmer's express
+    Statement of Purpose.
+
+    3. Public License Fallback. Should any part of the Waiver for any reason be
+    judged legally invalid or ineffective under applicable law, then the Waiver
+    shall be preserved to the maximum extent permitted taking into account
+    Affirmer's express Statement of Purpose. In addition, to the extent the
+    Waiver is so judged Affirmer hereby grants to each affected person a
+    royalty-free, non transferable, non sublicensable, non exclusive,
+    irrevocable and unconditional license to exercise Affirmer's Copyright and
+    Related Rights in the Work (i) in all territories worldwide, (ii) for the
+    maximum duration provided by applicable law or treaty (including future time
+    extensions), (iii) in any current or future medium and for any number of
+    copies, and (iv) for any purpose whatsoever, including without limitation
+    commercial, advertising or promotional purposes (the "License"). The License
+    shall be deemed effective as of the date CC0 was applied by Affirmer to the
+    Work. Should any part of the License for any reason be judged legally
+    invalid or ineffective under applicable law, such partial invalidity or
+    ineffectiveness shall not invalidate the remainder of the License, and in
+    such case Affirmer hereby affirms that he or she will not (i) exercise any
+    of his or her remaining Copyright and Related Rights in the Work or (ii)
+    assert any associated claims and causes of action with respect to the Work,
+    in either case contrary to Affirmer's express Statement of Purpose.
+
+    4. Limitations and Disclaimers.
+
+        a. No trademark or patent rights held by Affirmer are waived, abandoned,
+        surrendered, licensed or otherwise affected by this document.
+
+        b. Affirmer offers the Work as-is and makes no representations or
+        warranties of any kind concerning the Work, express, implied, statutory
+        or otherwise, including without limitation warranties of title,
+        merchantability, fitness for a particular purpose, non infringement, or
+        the absence of latent or other defects, accuracy, or the present or
+        absence of errors, whether or not discoverable, all to the greatest
+        extent permissible under applicable law.
+
+        c. Affirmer disclaims responsibility for clearing rights of other
+        persons that may apply to the Work or any use thereof, including without
+        limitation any person's Copyright and Related Rights in the Work.
+        Further, Affirmer disclaims responsibility for obtaining any necessary
+        consents, permissions or other rights required for any use of the Work.
+
+        d. Affirmer understands and acknowledges that Creative Commons is not a
+        party to this document and has no duty or obligation with respect to
+        this CC0 or use of the Work.

--- a/licenses/mit.txt
+++ b/licenses/mit.txt
@@ -1,0 +1,22 @@
+MIT License
+===========
+
+Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/readme.rst
+++ b/readme.rst
@@ -87,6 +87,12 @@ Features:
 
   - Available in PDF format in English and Spanish.
 
+- License:
+
+  - The library is licensed under the MIT license.
+  - The assets in this repository are licensed under the CC-BY-4.0 license.
+  - The examples are licensed under the CC0 license.
+
 Setup instructions for devkitPro
 ================================
 

--- a/source/nf_2d.c
+++ b/source/nf_2d.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones 2D comunes
 // http://www.nightfoxandco.com/

--- a/source/nf_3d.c
+++ b/source/nf_3d.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones 2D comunes
 // http://www.nightfoxandco.com/

--- a/source/nf_affinebg.c
+++ b/source/nf_affinebg.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de Fondos Affine
 // http://www.nightfoxandco.com/

--- a/source/nf_basic.c
+++ b/source/nf_basic.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones basicas y de Debug
 // http://www.nightfoxandco.com/

--- a/source/nf_bitmapbg.c
+++ b/source/nf_bitmapbg.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones de fondos en modo Bitmap
 // http://www.nightfoxandco.com/

--- a/source/nf_colision.c
+++ b/source/nf_colision.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de Colisiones
 // http://www.nightfoxandco.com/

--- a/source/nf_media.c
+++ b/source/nf_media.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de funciones de carga de archivos multimedia
 // http://www.nightfoxandco.com/

--- a/source/nf_mixedbg.c
+++ b/source/nf_mixedbg.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Include de Fondos mixtos (Tiled / Bitmap 8 bits)
 // http://www.nightfoxandco.com/

--- a/source/nf_sound.c
+++ b/source/nf_sound.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de de funciones de sonido
 // http://www.nightfoxandco.com/

--- a/source/nf_sprite256.c
+++ b/source/nf_sprite256.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de Sprites a 256 colores
 // http://www.nightfoxandco.com/

--- a/source/nf_sprite3d.c
+++ b/source/nf_sprite3d.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones 2D comunes
 // http://www.nightfoxandco.com/

--- a/source/nf_text.c
+++ b/source/nf_text.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de Textos
 // http://www.nightfoxandco.com/

--- a/source/nf_text16.c
+++ b/source/nf_text16.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de Textos de 16 pixeles
 // http://www.nightfoxandco.com/

--- a/source/nf_tiledbg.c
+++ b/source/nf_tiledbg.c
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: CC-BY-4.0
+// SPDX-License-Identifier: MIT
 //
-// Copyright (c) 2011-2014 Cesar Rincon "NightFox"
+// Copyright (c) 2009-2014 Cesar Rincon "NightFox"
 //
 // NightFox LIB - Funciones de Fondos con tiles
 // http://www.nightfoxandco.com/

--- a/template/source/main.c
+++ b/template/source/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: NightFox & Co., 2009-2011
+
 /*
 -------------------------------------------------
 
@@ -9,8 +13,6 @@
 	Codigo por NightFox
 	http://www.nightfoxandco.com
 	Inicio 10 de Octubre del 2009
-
-	(c)2009 - 2011 NightFox & Co.
 
 -------------------------------------------------
 */


### PR DESCRIPTION
- Creative Commons (except for CC0) shouldn't be used for code:

   https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software

   MIT has the same spirit as the CC-BY license.

- CC-BY has been retained for the assets included in the repository.

- Also, the years were wrong, this library was started in 2009.

- Make all examples use the CC0 license.