### PR TITLE
Do not force libfilesystem or libfat dependency

### DIFF
--- a/examples/3dsprites/alpha/source/main.c
+++ b/examples/3dsprites/alpha/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -60,6 +61,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 	consoleClear();
 

--- a/examples/3dsprites/animation/source/main.c
+++ b/examples/3dsprites/animation/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -64,6 +65,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 3D

--- a/examples/3dsprites/basic/source/main.c
+++ b/examples/3dsprites/basic/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -62,6 +63,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 3D

--- a/examples/3dsprites/rotscale/source/main.c
+++ b/examples/3dsprites/rotscale/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -63,6 +64,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 3D

--- a/examples/3dsprites/setlayer/source/main.c
+++ b/examples/3dsprites/setlayer/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -64,6 +65,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 3D

--- a/examples/3dsprites/setpriority/source/main.c
+++ b/examples/3dsprites/setpriority/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -63,6 +64,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 3D

--- a/examples/3dsprites/swappriority/source/main.c
+++ b/examples/3dsprites/swappriority/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -63,6 +64,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 3D

--- a/examples/colisions/barrels/source/main.c
+++ b/examples/colisions/barrels/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -59,6 +60,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/colisions/pixels/source/main.c
+++ b/examples/colisions/pixels/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/colisions/tiles/source/main.c
+++ b/examples/colisions/tiles/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/demo/reveal/source/main.c
+++ b/examples/demo/reveal/source/main.c
@@ -36,6 +36,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -61,6 +62,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/demo/water/source/main.c
+++ b/examples/demo/water/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -75,6 +76,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/demo/wave/source/main.c
+++ b/examples/demo/wave/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -74,6 +75,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/demo/zoomx2/source/main.c
+++ b/examples/demo/zoomx2/source/main.c
@@ -36,6 +36,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -61,6 +62,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/demo/zoomx3/source/main.c
+++ b/examples/demo/zoomx3/source/main.c
@@ -37,6 +37,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -62,6 +63,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/affine/source/main.c
+++ b/examples/graphics/affine/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -63,6 +64,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/alpha/source/main.c
+++ b/examples/graphics/alpha/source/main.c
@@ -36,6 +36,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -61,6 +62,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/animatedbg/source/main.c
+++ b/examples/graphics/animatedbg/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -78,6 +79,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/backbuffer2/source/main.c
+++ b/examples/graphics/backbuffer2/source/main.c
@@ -36,6 +36,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -61,6 +62,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/backbuffer3/source/main.c
+++ b/examples/graphics/backbuffer3/source/main.c
@@ -37,6 +37,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -62,6 +63,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/backbuffer4/source/main.c
+++ b/examples/graphics/backbuffer4/source/main.c
@@ -36,6 +36,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -61,6 +62,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/bg/source/main.c
+++ b/examples/graphics/bg/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -62,6 +63,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/bg16bitsload/source/main.c
+++ b/examples/graphics/bg16bitsload/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -60,6 +61,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/bg8bits/source/main.c
+++ b/examples/graphics/bg8bits/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -60,6 +61,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/bgextpalette/source/main.c
+++ b/examples/graphics/bgextpalette/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -66,6 +67,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/bgmixed/source/main.c
+++ b/examples/graphics/bgmixed/source/main.c
@@ -36,6 +36,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -61,6 +62,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/bgpalette/source/main.c
+++ b/examples/graphics/bgpalette/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/imgdraw/source/main.c
+++ b/examples/graphics/imgdraw/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -60,6 +61,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/graphics/sprite/source/main.c
+++ b/examples/graphics/sprite/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -59,6 +60,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/spritepal/source/main.c
+++ b/examples/graphics/spritepal/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -59,6 +60,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/tilechange/source/main.c
+++ b/examples/graphics/tilechange/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/graphics/tileflip/source/main.c
+++ b/examples/graphics/tileflip/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -62,6 +63,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/media/bmpload/source/main.c
+++ b/examples/media/bmpload/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -63,6 +64,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/media/bmpscroll/source/main.c
+++ b/examples/media/bmpscroll/source/main.c
@@ -35,6 +35,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -60,6 +61,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D en modo BITMAP

--- a/examples/sound/rawsfx/source/main.c
+++ b/examples/sound/rawsfx/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/text/text16/source/main.c
+++ b/examples/text/text16/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include "nf_lib.h"
@@ -66,6 +67,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/text/textcolor/source/main.c
+++ b/examples/text/textcolor/source/main.c
@@ -34,6 +34,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -66,6 +67,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/text/textdemo/source/main.c
+++ b/examples/text/textdemo/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/text/textdemo16/source/main.c
+++ b/examples/text/textdemo16/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/examples/text/textscroll/source/main.c
+++ b/examples/text/textscroll/source/main.c
@@ -33,6 +33,7 @@
 
 // Includes propietarios NDS
 #include <nds.h>
+#include <filesystem.h>
 
 // Includes librerias propias
 #include <nf_lib.h>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
 	swiWaitForVBlank();
 
 	// Define el ROOT e inicializa el sistema de archivos
+	nitroFSInit(NULL);
 	NF_SetRootFolder("NITROFS");	// Define la carpeta ROOT para usar NITROFS
 
 	// Inicializa el motor 2D

--- a/source/nf_affinebg.c
+++ b/source/nf_affinebg.c
@@ -10,8 +10,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_basic.c
+++ b/source/nf_basic.c
@@ -13,8 +13,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>
@@ -185,8 +183,9 @@ void NF_SetRootFolder(const char* folder) {
 
 		// Define NitroFS como la carpeta inicial
 		sprintf(NF_ROOTFOLDER, "%s", "");
-		// Intenta inicializar NitroFS
-		if(nitroFSInit(NULL)) {
+		// Check if NitroFS exists.
+		// NitroFS must be mounted beforehand for this to work.
+		if(access("nitro:/", F_OK) == 0) {
 			// NitroFS ok
 			// Si es correcto, cambia al ROOT del NitroFS
 			chdir("nitro:/");
@@ -219,8 +218,13 @@ void NF_SetRootFolder(const char* folder) {
 
 		// Define la carpeta inicial de la FAT
 		sprintf(NF_ROOTFOLDER, "%s", folder);
-		// Intenta inicializar la FAT
-		if (fatInitDefault()) {
+		// Check if DSi SD (sd:/) exists.
+		// If this fails, check if DLDI (fat:/) exists.
+		// If both fails, then fatInitDefault() either failed, or was not called.
+		if (access("sd:/", F_OK) == 0) {
+			// Si es correcto, cambia al ROOT del SD
+			chdir("sd:/");
+		} else if (access("fat:/", F_OK) == 0) {
 			// Si es correcto, cambia al ROOT del FAT
 			chdir("fat:/");
 		} else {

--- a/source/nf_bitmapbg.c
+++ b/source/nf_bitmapbg.c
@@ -10,8 +10,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_colision.c
+++ b/source/nf_colision.c
@@ -10,8 +10,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_media.c
+++ b/source/nf_media.c
@@ -10,8 +10,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_mixedbg.c
+++ b/source/nf_mixedbg.c
@@ -12,8 +12,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_sound.c
+++ b/source/nf_sound.c
@@ -12,8 +12,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_sprite256.c
+++ b/source/nf_sprite256.c
@@ -12,8 +12,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_text.c
+++ b/source/nf_text.c
@@ -10,8 +10,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_text16.c
+++ b/source/nf_text16.c
@@ -10,8 +10,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>

--- a/source/nf_tiledbg.c
+++ b/source/nf_tiledbg.c
@@ -12,8 +12,6 @@
 
 // Includes devKitPro
 #include <nds.h>
-#include <filesystem.h>
-#include <fat.h>
 
 // Includes C
 #include <stdio.h>


### PR DESCRIPTION
This removes dependency from the (frankly awful) libfilesystem, as well as libfat.

fatInitDefault() or nitroFSInit() should be initialized outside of NFlib, if one requires it. Within NFLib, we will only check whether NitroFS is accessible, and fail otherwise.

This allows a user to still use libfat, libfilesystem or any other NitroFS / FAT implementation, should one wish to use it, as long as the implementation of NitroFS mounts to `nitro:/`, or the storage medium is mounted to `sd:/` or `fat:/`.

This is a breaking change: users will need to update their code to handle NitroFS and/or FAT inits on their own.

This also removes unnecessary filesystem.h and fat.h includes from all other files.